### PR TITLE
Revert CNAME file remove

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+learnmeabitcoin.simorgh.me


### PR DESCRIPTION
فایل CNAME که به اشتباه توی کامیت 3183d5b2ce837ab85c8bcd855d339053daaee50d یا PR https://github.com/rezatajari/learnmeabitcoin/pull/37 حذف شده بود رو برمیگردونه.